### PR TITLE
feat: Add JWT authentication support and update OIDC configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.0",
         "@hapi/hoek": "^11.0.7",
+        "@hapi/jwt": "3.2.0",
         "aws-embedded-metrics": "4.2.0",
         "aws4": "^1.13.2",
         "convict": "^6.2.4",
@@ -56,6 +57,7 @@
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "lint-staged": "^16.1.2",
+        "oidc-client-ts": "3.3.0",
         "prettier": "^3.5.3",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3"
@@ -2695,6 +2697,16 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hapi/catbox-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-object/-/catbox-object-3.0.1.tgz",
+      "integrity": "sha512-3w6E2DXtjWbmLYi4WcFUOor5jgrXN4PWhDrMrXKP/cEsFSfVSRJ0FhY2PXrhrUHwcllfKezYafWU3tQ5+8RO1w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@hapi/content": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
@@ -2780,6 +2792,30 @@
         "@hapi/cryptiles": "^6.0.1",
         "@hapi/hoek": "^11.0.2"
       }
+    },
+    "node_modules/@hapi/jwt": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/jwt/-/jwt-3.2.0.tgz",
+      "integrity": "sha512-2EU5zdr0petG63J2RHiagGByA1Qr6qzxMmrJJ3/0cm78be1Lq4vi038YgKJvbBSxSboIp5SWGZdYB6+CJlqEoQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/catbox-object": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/wreck": "^18.0.0",
+        "ecdsa-sig-formatter": "^1.0.0",
+        "joi": "^17.2.1"
+      }
+    },
+    "node_modules/@hapi/jwt/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/mimos": {
       "version": "7.0.1",
@@ -6634,6 +6670,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/editorconfig-checker": {
@@ -10976,6 +11021,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11756,6 +11811,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.3.0.tgz",
+      "integrity": "sha512-t13S540ZwFOEZKLYHJwSfITugupW4uYLwuQSSXyKH/wHwZ+7FvgHE7gnNJh1YQIZ1Yd1hKSRjqeXGSUtS0r9JA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/on-exit-leak-free": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.0",
     "@hapi/hoek": "^11.0.7",
+    "@hapi/jwt": "3.2.0",
     "aws-embedded-metrics": "4.2.0",
     "aws4": "^1.13.2",
     "convict": "^6.2.4",
@@ -83,6 +84,7 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "lint-staged": "^16.1.2",
+    "oidc-client-ts": "3.3.0",
     "prettier": "^3.5.3",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,6 +9,7 @@ import { failAction } from '~/src/helpers/fail-action.js'
 import { requestLogger } from '~/src/helpers/logging/request-logger.js'
 import { requestTracing } from '~/src/helpers/request-tracing.js'
 import { prepareDb } from '~/src/mongo.js'
+import { auth } from '~/src/plugins/auth/index.js'
 import { router } from '~/src/plugins/router.js'
 import { prepareSecureContext } from '~/src/secure-context.js'
 
@@ -29,6 +30,9 @@ export async function createServer() {
   const server = hapi.server({
     port: config.get('port'),
     routes: {
+      auth: {
+        mode: 'required'
+      },
       validate: {
         options: {
           abortEarly: false
@@ -54,6 +58,7 @@ export async function createServer() {
     }
   })
 
+  await server.register(auth)
   await server.register(requestLogger)
   await server.register(requestTracing)
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -138,26 +138,26 @@ export const config = convict({
     doc: 'The URI that defines the OIDC json web key set',
     format: String,
     default:
-      'https://login.microsoftonline.com/770a2450-0227-4c62-90c7-4e38537f1102/discovery/v2.0/keys',
+      'https://login.microsoftonline.com/6f504113-6b64-43f2-ade9-242e05780007/discovery/v2.0/keys',
     env: 'OIDC_JWKS_URI'
   },
   oidcVerifyAud: {
     doc: 'The audience used for verifying the OIDC JWT',
     format: String,
-    default: 'ec32e5c5-75fa-460a-a359-e3e5a4a8f10e',
+    default: '6be2d9fd-fe1e-47eb-9821-b6f6cd3ceba1',
     env: 'OIDC_VERIFY_AUD'
   },
   oidcVerifyIss: {
     doc: 'The issuer used for verifying the OIDC JWT',
     format: String,
     default:
-      'https://login.microsoftonline.com/770a2450-0227-4c62-90c7-4e38537f1102/v2.0',
+      'https://login.microsoftonline.com/6f504113-6b64-43f2-ade9-242e05780007/v2.0',
     env: 'OIDC_VERIFY_ISS'
   },
   roleEditorGroupId: {
     doc: 'The AD security group the access token needs to claim membership of',
     format: String,
-    default: '9af646c4-fa14-4606-8ebf-ec187ac03386',
+    default: '7049296f-2156-4d61-8ac3-349276438ef9',
     env: 'ROLE_EDITOR_GROUP_ID'
   },
   tracing: {

--- a/src/plugins/auth/auth.test.js
+++ b/src/plugins/auth/auth.test.js
@@ -1,0 +1,255 @@
+const mockActualTestErrorFn = jest.fn()
+const mockActualTestWarnFn = jest.fn()
+const mockActualTestInfoFn = jest.fn()
+
+jest.mock('~/src/helpers/logging/logger.js', () => ({
+  createLogger: jest.fn().mockReturnValue({
+    error: mockActualTestErrorFn,
+    warn: mockActualTestWarnFn,
+    info: mockActualTestInfoFn
+  })
+}))
+
+jest.mock('~/src/config/index.js', () => ({
+  config: {
+    get: jest.fn((key) => {
+      if (key === 'roleEditorGroupId') return 'editor-group-id'
+      return 'mock-value'
+    })
+  }
+}))
+
+jest.mock('@hapi/jwt')
+
+describe('auth plugin', () => {
+  /** @type {AuthModule} */
+  let authModule
+  /** @type {Auth} */
+  let auth
+  /** @type {ValidateFn} */
+  let validateFn
+  /** @type {Jwt} */
+  let Jwt
+
+  const server = {
+    register: jest.fn().mockResolvedValue(undefined),
+    auth: {
+      strategy: jest.fn(),
+      default: jest.fn()
+    }
+  }
+
+  beforeEach(async () => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    const jwtModule = await import('@hapi/jwt')
+    Jwt = /** @type {Jwt} */ (jwtModule.default)
+
+    authModule = await import('~/src/plugins/auth/index.js')
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    auth = authModule.auth
+  })
+
+  test('should register the JWT plugin', async () => {
+    await auth.plugin.register(/** @type {any} */ (server))
+    expect(server.register).toHaveBeenCalledWith(Jwt)
+  })
+
+  test('should set up the auth strategy', async () => {
+    await auth.plugin.register(/** @type {any} */ (server))
+    expect(server.auth.strategy).toHaveBeenCalledWith(
+      'azure-oidc-token',
+      'jwt',
+      expect.objectContaining({
+        keys: expect.any(Object),
+        verify: expect.any(Object),
+        validate: expect.any(Function)
+      })
+    )
+  })
+
+  test('should set the default auth strategy', async () => {
+    await auth.plugin.register(/** @type {any} */ (server))
+    expect(server.auth.default).toHaveBeenCalledWith('azure-oidc-token')
+  })
+
+  describe('validate function', () => {
+    beforeEach(async () => {
+      await auth.plugin.register(/** @type {any} */ (server))
+      if (server.auth.strategy.mock.calls.length > 0) {
+        const strategyOptions = /** @type {{ validate: ValidateFn }} */ (
+          server.auth.strategy.mock.calls[
+            server.auth.strategy.mock.calls.length - 1
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          ][2]
+        )
+        validateFn = strategyOptions.validate
+      } else {
+        validateFn = () => ({ isValid: false })
+      }
+    })
+
+    test('should return isValid: false when user is missing from payload', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: null
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestInfoFn).toHaveBeenCalledWith(
+        '[authMissingUser] Auth: Missing user from token payload.'
+      )
+    })
+
+    test('should return isValid: false when oid is missing', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            groups: ['some-group']
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestInfoFn).toHaveBeenCalledWith(
+        '[authMissingOID] Auth: User OID is missing in token payload.'
+      )
+    })
+
+    test('should handle string groups claim that is valid JSON array', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid',
+            groups: JSON.stringify(['editor-group-id'])
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({
+        isValid: true,
+        credentials: {
+          user: {
+            oid: 'test-oid',
+            groups: ['editor-group-id']
+          }
+        }
+      })
+    })
+
+    test('should handle string groups claim that is not a valid JSON array', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid',
+            groups: JSON.stringify({ notAnArray: true })
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestWarnFn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[authGroupsInvalid] Auth: User test-oid: 'groups' claim was string but not valid JSON array"
+        )
+      )
+    })
+
+    test('should handle parsing error for string groups claim', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid',
+            groups: '{invalid-json'
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestErrorFn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[authGroupsParseError] Auth: User test-oid: Failed to parse 'groups' claim"
+        )
+      )
+    })
+
+    test('should handle array groups claim directly', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid',
+            groups: ['editor-group-id']
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({
+        isValid: true,
+        credentials: {
+          user: {
+            oid: 'test-oid',
+            groups: ['editor-group-id']
+          }
+        }
+      })
+    })
+
+    test('should handle missing groups claim by setting an empty array', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid'
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestWarnFn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[authGroupNotFound] Auth: User test-oid: Authorisation failed. Required group "editor-group-id" not found'
+        )
+      )
+    })
+
+    test('should return isValid: false when required group is not in groups array', () => {
+      const artifacts = /** @type {any} */ ({
+        decoded: {
+          payload: {
+            oid: 'test-oid',
+            groups: ['some-other-group']
+          }
+        }
+      })
+      const result = validateFn(artifacts)
+      expect(result).toEqual({ isValid: false })
+      expect(mockActualTestWarnFn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[authGroupNotFound] Auth: User test-oid: Authorisation failed. Required group "editor-group-id" not found'
+        )
+      )
+    })
+  })
+})
+
+/**
+ * @typedef {typeof AuthModuleDefinitionStar} AuthModule
+ */
+/**
+ * @typedef {AuthTypeDefinition} Auth
+ */
+/**
+ * @typedef {(artifacts: Artifacts<UserCredentials>) => ({ isValid: boolean, credentials?: any })} ValidateFn
+ */
+/**
+ * @typedef {jest.Mocked<JwtTypeDefinition>} Jwt
+ */
+
+/**
+ * @import { UserCredentials } from '@hapi/hapi'
+ * @import { Artifacts } from '~/src/plugins/auth/types.js'
+ * @import * as AuthModuleDefinitionStar from '~/src/plugins/auth/index.js'
+ * @import { auth as AuthTypeDefinition } from '~/src/plugins/auth/index.js'
+ * @import { default as JwtTypeDefinition } from '@hapi/jwt'
+ */

--- a/src/plugins/auth/index.js
+++ b/src/plugins/auth/index.js
@@ -1,0 +1,130 @@
+import Jwt from '@hapi/jwt'
+
+import { config } from '~/src/config/index.js'
+import { getErrorMessage } from '~/src/helpers/error-message.js'
+import { createLogger } from '~/src/helpers/logging/logger.js'
+
+const oidcJwksUri = config.get('oidcJwksUri')
+const oidcVerifyAud = config.get('oidcVerifyAud')
+const oidcVerifyIss = config.get('oidcVerifyIss')
+const roleEditorGroupId = config.get('roleEditorGroupId')
+
+const logger = createLogger()
+
+/**
+ * Processes the groups claim from the token payload
+ * @param {unknown} groupsClaim - The groups claim from the token
+ * @param {string} oid - User OID for logging purposes
+ * @returns {string[]} Processed groups array
+ */
+function processGroupsClaim(groupsClaim, oid) {
+  let processedGroups = []
+
+  // For the integration tests, the OIDC mock server sends the 'groups' claim as a stringified JSON array which
+  // requires parsing, while a real Azure AD would typically provide 'groups' as a proper array.
+  // We handle both formats for flexibility between test and production environments.
+  if (typeof groupsClaim === 'string') {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- we know this is a stringified JSON array
+      const parsed = JSON.parse(groupsClaim)
+      if (Array.isArray(parsed)) {
+        processedGroups = parsed
+      } else {
+        logger.warn(
+          `[authGroupsInvalid] Auth: User ${oid}: 'groups' claim was string but not valid JSON array: '${String(groupsClaim)}'`
+        )
+      }
+    } catch (error) {
+      logger.error(
+        `[authGroupsParseError] Auth: User ${oid}: Failed to parse 'groups' claim - ${getErrorMessage(error)}`
+      )
+    }
+  } else if (Array.isArray(groupsClaim)) {
+    processedGroups = groupsClaim
+  } else {
+    processedGroups = []
+  }
+
+  return processedGroups
+}
+
+/**
+ * Validates user credentials from JWT token
+ * @param {Artifacts<UserCredentials>} artifacts - JWT artifacts
+ * @returns {{ isValid: boolean, credentials?: any }} Validation result
+ */
+function validateUserCredentials(artifacts) {
+  const user = artifacts.decoded.payload
+
+  if (!user) {
+    logger.info('[authMissingUser] Auth: Missing user from token payload.')
+    return {
+      isValid: false
+    }
+  }
+
+  const { oid } = user
+  const groupsClaim = user.groups
+
+  if (!oid) {
+    logger.info('[authMissingOID] Auth: User OID is missing in token payload.')
+    return {
+      isValid: false
+    }
+  }
+
+  const processedGroups = processGroupsClaim(groupsClaim, oid)
+
+  if (!processedGroups.includes(roleEditorGroupId)) {
+    logger.warn(
+      `[authGroupNotFound] Auth: User ${oid}: Authorisation failed. Required group "${roleEditorGroupId}" not found`
+    )
+    return {
+      isValid: false
+    }
+  }
+
+  return {
+    isValid: true,
+    credentials: {
+      user: {
+        ...user,
+        groups: processedGroups
+      }
+    }
+  }
+}
+
+/**
+ * @satisfies {ServerRegisterPluginObject<void>}
+ */
+export const auth = {
+  plugin: {
+    name: 'auth',
+    async register(server) {
+      await server.register(Jwt)
+
+      server.auth.strategy('azure-oidc-token', 'jwt', {
+        keys: {
+          uri: oidcJwksUri
+        },
+        verify: {
+          aud: oidcVerifyAud,
+          iss: oidcVerifyIss,
+          sub: false,
+          nbf: true,
+          exp: true
+        },
+        validate: validateUserCredentials
+      })
+
+      // Set as the default strategy
+      server.auth.default('azure-oidc-token')
+    }
+  }
+}
+
+/**
+ * @import { ServerRegisterPluginObject, UserCredentials } from '@hapi/hapi'
+ * @import { Artifacts } from '~/src/plugins/auth/types.js'
+ */

--- a/src/plugins/auth/types.js
+++ b/src/plugins/auth/types.js
@@ -1,0 +1,9 @@
+/**
+ * @import { HapiJwt } from '@hapi/jwt'
+ * @import { IdTokenClaims } from 'oidc-client-ts'
+ */
+
+/**
+ * @template {object} Payload
+ * @typedef {HapiJwt.Artifacts<{ JwtPayload?: Payload }>} Artifacts
+ */

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -2,8 +2,8 @@ export const auth = {
   strategy: 'azure-oidc-token',
   credentials: {
     user: {
-      aud: 'api://2bf2d9fd-fe1e-47eb-9821-b6f6cd3ceba1',
-      iss: 'https://sts.windows.net/5b504113-6b64-43f2-ade9-242e05780008/',
+      aud: '6be2d9fd-fe1e-47eb-9821-b6f6cd3ceba1',
+      iss: 'https://login.microsoftonline.com/6f504113-6b64-43f2-ade9-242e05780007/v2.0',
       family_name: 'Chase',
       given_name: 'Enrique',
       groups: ['7049296f-2156-4d61-8ac3-349276438ef9'],


### PR DESCRIPTION
- Integrated @hapi/jwt for JWT authentication in the server.
- Created auth plugin to handle user validation and group claims.
- Updated OIDC configuration values in the config module.
- Added tests for the auth plugin to ensure proper functionality.
- Included new dependencies in package.json and package-lock.json.