### PR TITLE
Add new dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,95 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group into shared PRs
+    groups:
+      build:
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+          - 'typescript'
+
+      lint:
+        patterns:
+          - 'editorconfig-checker'
+          - 'eslint'
+          - 'eslint-*'
+          - 'husky'
+          - 'lint-staged'
+          - 'prettier'
+
+      logging:
+        patterns:
+          - '*-pino'
+          - '*-pino-format'
+          - 'pino'
+          - 'pino-*'
+
+      tools:
+        patterns:
+          - 'jest'
+          - 'tsx'
+
+      types:
+        patterns:
+          - '@types/*'
+          - 'oidc-client-ts'
+
+      forms:
+        patterns:
+          - '@defra/forms-model'
+
+      aws:
+        patterns:
+          - '@aws-sdk/*'
+          - 'aws-embedded-metrics'
+
+      hapi:
+        patterns:
+          - '@hapi/*'
+          - 'hapi-*'
+          - 'joi'
+
+      runtime:
+        patterns:
+          - '@defra/hapi-tracing'
+          - 'dotenv'
+          - 'mongodb'
+
+      dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - patch
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    groups:
+      actions:
+        patterns:
+          - '*'
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'


### PR DESCRIPTION
Add new dependabot groups to make managing dependencies less noisy. Also adds a final catch-all group for any dependencies that are patch releases and easy to update.